### PR TITLE
Suppress the software and job information

### DIFF
--- a/src/glite-info-provider-ldap
+++ b/src/glite-info-provider-ldap
@@ -263,7 +263,7 @@ foreach(@urls){
 		    $bind = "GLUE2DomainId=$site,o=glue";
 	        }
             }
-	    $filter = ''
+	    $filter = "'(!(|(objectClass=GLUE2ApplicationEnvironment)(objectClass=GLUE2Activity)))'"
 	}else{
 	    $bind = $4;
 	}


### PR DESCRIPTION
Stops the software and job entries being consumed by the top-level BDII.