### PR TITLE
Prepare new release 1.6.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,8 @@ jobs:
 
   release7:
     name: Upload CentOS 7 release artefacts
+    permissions:
+      contents: write # to upload release asset (softprops/action-gh-release)
     needs: centos7
     runs-on: ubuntu-latest
     steps:
@@ -106,6 +108,8 @@ jobs:
 
   release8:
     name: Upload AlmaLinux 8 release artefacts
+    permissions:
+      contents: write # to upload release asset (softprops/action-gh-release)
     needs: almalinux8
     runs-on: ubuntu-latest
     steps:
@@ -131,6 +135,8 @@ jobs:
 
   release9:
     name: Upload AlmaLinux 9 release artefacts
+    permissions:
+      contents: write # to upload release asset (softprops/action-gh-release)
     needs: almalinux9
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.6.0] - 2023-04-04
+
+### Changed
+
+- Build and release using CentOS 7, AlmaLinux 8 and 9. (#12) (Baptiste Grenier)
+- Sync repo with other bdii-related ones. (#12) (Baptiste Grenier)
+
 ## [1.5.0] - 2022-09-07
 - Suppress the software and job information (#2) (Laurence Field)
 - Use GitHub Actions to lint, build, and upload packages to GitHub (#5) (Baptiste Grenier)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+glite-info-provider-ldap (1.6.0-1) UNRELEASED; urgency=low
+
+  * Build and release using CentOS 7, AlmaLinux 8 and 9. (#12) (Baptiste Grenier)
+  * Sync repo with other bdii-related ones. (#12) (Baptiste Grenier)
+
+ -- Baptiste Grenier <baptiste.grenier@egi.eu>  Tue, 04 Apr 2023 09:24:00 +0100
+
 glite-info-provider-ldap (1.5.0-1) UNRELEASED; urgency=low
 
   * Suppress the software and job information (#2) (Laurence Field)

--- a/glite-info-provider-ldap.spec
+++ b/glite-info-provider-ldap.spec
@@ -1,5 +1,5 @@
 Name:          glite-info-provider-ldap
-Version:       1.5.0
+Version:       1.6.0
 Release:       1%{?dist}
 Summary:       LDAP information provider
 Group:         Development/Libraries
@@ -40,6 +40,10 @@ rm -rf %{buildroot}
 %license /usr/share/licenses/%{name}-%{version}/LICENSE.txt
 
 %changelog
+
+* Tue Apr 4 2023 Baptiste Grenier <baptiste.grenier@egi.eu> - 1.6.0-1
+- Build and release using CentOS 7, AlmaLinux 8 and 9. (#12) (Baptiste Grenier)
+- Sync repo with other bdii-related ones. (#12) (Baptiste Grenier)
 
 * Wed Sep 7 2022 Baptiste Grenier <baptiste.grenier@egi.eu> - 1.5.0-1
 - Suppress the software and job information (#2) (Laurence Field)


### PR DESCRIPTION
Prepare new release 1.6.0.

```markdown
## [1.6.0] - 2023-04-04

### Changed

- Build and release using CentOS 7, AlmaLinux 8 and 9. (#12) (Baptiste Grenier)
- Sync repo with other bdii-related ones. (#12) (Baptiste Grenier)
```